### PR TITLE
fix(streamdown): apply per-block dir in static mode when dir="auto"

### DIFF
--- a/packages/streamdown/__tests__/rtl-support.test.tsx
+++ b/packages/streamdown/__tests__/rtl-support.test.tsx
@@ -206,5 +206,51 @@ Mixed paragraph: Hello مرحبا World عالم.
       const dirElements = container.querySelectorAll("[dir]");
       expect(dirElements.length).toBe(0);
     });
+
+    it('applies per-block dir in static mode with dir="auto" for mixed content', () => {
+      // Document mixes Hebrew and English across multiple blocks. Prior to
+      // the fix, static mode set a single dir on the outer wrapper based on
+      // the first strong character, so RTL blocks were rendered in an LTR
+      // container (or vice versa). With the fix, each block gets its own
+      // detected direction — matching streaming mode behavior.
+      const mixedContent = `Here is a sentence in English with עברית באמצע.
+
+זה משפט בעברית שמשולב עם English באמצע.
+
+# English heading
+
+# כותרת בעברית`;
+
+      const { container } = render(
+        <Streamdown dir="auto" mode="static">
+          {mixedContent}
+        </Streamdown>
+      );
+
+      const dirElements = container.querySelectorAll("[dir]");
+      // Should have multiple dir elements (one per block) — not a single
+      // container-level dir as was the case before the fix.
+      expect(dirElements.length).toBeGreaterThanOrEqual(4);
+
+      const dirValues = Array.from(dirElements).map((el) =>
+        el.getAttribute("dir")
+      );
+      // Both directions should be present because each block is detected
+      // independently based on its own first strong character.
+      expect(dirValues).toContain("ltr");
+      expect(dirValues).toContain("rtl");
+    });
+
+    it('does not apply dir to outer wrapper in static mode with dir="auto"', () => {
+      // When dir="auto" in static mode we push direction down to each block
+      // rather than setting a single direction on the root wrapper.
+      const { container } = render(
+        <Streamdown dir="auto" mode="static">
+          {"Hello\n\nשלום"}
+        </Streamdown>
+      );
+      const outer = container.firstElementChild as HTMLElement;
+      expect(outer.hasAttribute("dir")).toBe(false);
+    });
   });
 });

--- a/packages/streamdown/index.tsx
+++ b/packages/streamdown/index.tsx
@@ -754,7 +754,11 @@ export const Streamdown = memo(
       [caret, isAnimating, shouldHideCaret]
     );
 
-    // Static mode: simple rendering without streaming features
+    // Static mode: simple rendering without streaming features.
+    // When dir="auto", render per-block so each block gets its own direction
+    // detected via the "first strong character" algorithm. This matches the
+    // behavior of streaming mode and prevents mixed RTL/LTR content from
+    // getting a single, incorrect direction for the whole document.
     if (mode === "static") {
       return (
         <TranslationsContext.Provider value={translationsValue}>
@@ -768,20 +772,36 @@ export const Streamdown = memo(
                       "space-y-4 whitespace-normal [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
                       className
                     )}
-                    dir={
-                      dir === "auto"
-                        ? detectTextDirection(processedChildren)
-                        : dir
-                    }
+                    dir={dir === "auto" ? undefined : dir}
                   >
-                    <Markdown
-                      components={mergedComponents}
-                      rehypePlugins={mergedRehypePlugins}
-                      remarkPlugins={mergedRemarkPlugins}
-                      {...props}
-                    >
-                      {processedChildren}
-                    </Markdown>
+                    {dir === "auto" ? (
+                      blocksToRender.map((block, index) => (
+                        <BlockComponent
+                          components={mergedComponents}
+                          content={block}
+                          dir={blockDirections?.[index]}
+                          index={index}
+                          isIncomplete={false}
+                          key={blockKeys[index]}
+                          rehypePlugins={mergedRehypePlugins}
+                          remarkPlugins={mergedRemarkPlugins}
+                          shouldNormalizeHtmlIndentation={
+                            shouldNormalizeHtmlIndentation
+                          }
+                          shouldParseIncompleteMarkdown={false}
+                          {...props}
+                        />
+                      ))
+                    ) : (
+                      <Markdown
+                        components={mergedComponents}
+                        rehypePlugins={mergedRehypePlugins}
+                        remarkPlugins={mergedRemarkPlugins}
+                        {...props}
+                      >
+                        {processedChildren}
+                      </Markdown>
+                    )}
                   </div>
                 </PrefixContext.Provider>
               </IconProvider>


### PR DESCRIPTION
Static mode previously ran detectTextDirection once on the full content and set a single `dir` on the outer wrapper. With mixed RTL/LTR documents this caused every block to inherit the direction of whichever language appeared first, producing the rendering issue reported in streamdown#<rtl-ltr-bug>.

Static mode now matches streaming mode: when dir="auto", the content is split into markdown blocks and each block renders inside a wrapper with its own detected direction. Explicit dir="ltr"/"rtl" continues to apply to the outer wrapper as before, and when dir is omitted no wrapper dir is added.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Related Issues

<!-- Link any related issues using #issue-number -->

Fixes #
Closes #
Related to #

## Changes Made

<!-- List the specific changes made in this PR -->

- 
- 
- 

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] All existing tests pass
- [ ] Added new tests for the changes
- [ ] Manually tested the changes

### Test Coverage

<!-- If applicable, include test coverage information -->

## Screenshots/Demos

<!-- If applicable, add screenshots or demos to help explain your changes -->

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have created a changeset (`pnpm changeset`)

## Changeset

<!-- Confirm you've created a changeset for this PR -->

- [ ] I have created a changeset for these changes

## Additional Notes

<!-- Add any additional notes, concerns, or discussion points -->